### PR TITLE
Fixed README.md to explicitly state the command which needs to be run…

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ cli config file. Add the `packagerOpts.config` property to your app.json, e.g.
 }
 ```
 
-If you need to run the packager directly from the command line, pass these
+If you need to run the packager directly from the command line, run the following
 
-    --transformer node_modules/react-native-typescript-transformer --sourceExts ts,tsx
+    react-native start --transformer node_modules/react-native-typescript-transformer/index.js --sourceExts ts,tsx
 
 ### Step 4: Write TypeScript code :D
 


### PR DESCRIPTION
… to invoke the typescript transformer with react-native package manager from the commandline.

Previous command triggered `EISDIR: illegal operation on a directory, read` on my fresh install of react-native@0.46  .  React-native was unable to infer `index.js` file to parse from the invocation of its parent dir.