### PR TITLE
fix(tsconfig): use find-root to find the nearest tsconfig.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 const ts = require('typescript')
 const fs = require('fs')
-const appRootPath = require('app-root-path')
+const findRoot = require('find-root')
 const os = require('os')
 const path = require('path')
 const process = require('process')
@@ -155,10 +155,12 @@ const tsConfig = (() => {
     console.warn(`resolved = ${resolvedTsconfigPath}`)
     console.warn('looking in app root directory')
   }
-  const tsConfigPath = appRootPath.resolve('tsconfig.json')
-  if (fs.existsSync(tsConfigPath)) {
-    return loadJsonFile(tsConfigPath)
-  }
+  const root = findRoot(process.cwd(), dir => {
+    const pkg = path.join(dir, 'tsconfig.json')
+    return fs.existsSync(pkg)
+  })
+  const tsConfigPath = path.join(root, 'tsconfig.json')
+  return loadJsonFile(tsConfigPath)
   throw new Error(`Unable to find tsconfig.json at ${tsConfigPath}`)
 })()
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "David Sheldrick",
   "license": "MIT",
   "dependencies": {
-    "app-root-path": "^2.0.1",
+    "find-root": "^1.1.0",
     "jju": "^1.3.0",
     "semver": "^5.4.1",
     "source-map": "^0.5.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -110,7 +110,7 @@ anymatch@^1.3.0:
     arrify "^1.0.0"
     micromatch "^2.1.5"
 
-app-root-path@^2.0.0, app-root-path@^2.0.1:
+app-root-path@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
@@ -1954,6 +1954,10 @@ finalhandler@0.4.0:
 find-parent-dir@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
 
 find-up@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
app-root-path relies on its own install location to determine the root of the project.
however, when using yarn workspaces, this assumption is incorrect.
this results in either not finding a tsconfig.json or finding a tsconfig.json that has been extended.
find-root allows passing a starting location and predicate and searches recursively up.