### PR TITLE
Added an ability to specify absolute path to tsconfig.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,6 +144,9 @@ function composeSourceMaps(tsMap, babelMap, tsFileName, tsContent, babelCode) {
 
 const tsConfig = (() => {
   if (TSCONFIG_PATH) {
+    if (fs.existsSync(TSCONFIG_PATH)) {
+        return loadJsonFile(TSCONFIG_PATH)
+    }
     const resolvedTsconfigPath = path.resolve(process.cwd(), TSCONFIG_PATH)
     if (fs.existsSync(resolvedTsconfigPath)) {
       return loadJsonFile(resolvedTsconfigPath)


### PR DESCRIPTION
If TSCONFIG_PATH is a valid path to `tsconfig.json` it will be resolved not related to `process.cwd()`.