### PR TITLE
Do not recommend "dom" TS library

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ If you use Jest as a test runner, add the following in your root package.json:
   ```patch
    {
      "compilerOptions": {
-  +    "lib": [ "es2015", "es2016", "es2017" ],
+  +    "lib": [ "es2017" ],
      }
    }
   ```

--- a/README.md
+++ b/README.md
@@ -141,10 +141,11 @@ If you use Jest as a test runner, add the following in your root package.json:
   ```patch
    {
      "compilerOptions": {
-  +    "lib": [ "dom", "es2015", "es2016" ],
+  +    "lib": [ "es2015", "es2016", "es2017" ],
      }
    }
   ```
+  Including the `"dom"` lib is not recommended. The React Native JavaScript runtime does not include any DOM-related APIs. See [JavaScript Environment](https://facebook.github.io/react-native/docs/javascript-environment) for more details on what web APIs React Native supports.
 
 ## Jest notes
 


### PR DESCRIPTION
I changed the README to include `es2017` and remove `dom`. The RN runtime includes polyfills for ES2017 static methods `Object.entries()` and `Object.values()` - they are implemented natively on iOS 10.3+ anyway.
I removed `dom` because that would allow a lot of invalid code to compile, since RN does not include any DOM APIs nor most of the browser Web APIs. The subset that is included is (mostly) defined in `@types/react-native`. Missing Web APIs will be added to `@types/react-native` as the community finds them.