### PR TITLE
update readme for latest metro bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,6 @@ module.exports = {
     babelTransformerPath: require.resolve(
       'react-native-typescript-transformer'
     )
-  },
-  resolver: {
-    sourceExts: ['js', 'ts', 'tsx']
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ Add this to your rn-cli.config.js (make one if you don't have one already):
 
 ```js
 module.exports = {
-  getTransformModulePath() {
-    return require.resolve('react-native-typescript-transformer');
+  transformer: {
+    babelTransformerPath: require.resolve(
+      'react-native-typescript-transformer'
+    )
   },
-  getSourceExts() {
-    return ['ts', 'tsx'];
+  resolver: {
+    sourceExts: ['js', 'ts', 'tsx']
   }
 }
 ```


### PR DESCRIPTION
When using the latest version of react native (0.57.4), the previous config did no longer work.
It might be practical to leave both in the readme, because older RN versions of course still require the old config.

I'm not sure when RN switched to the newer version of Metro, but I could look this up, and update the README with configuration examples before and after a certain RN version.