### PR TITLE
Fixed ReactNative >= 0.59 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ let upstreamTransformer = null
 const reactNativeVersionString = require('react-native/package.json').version
 const reactNativeMinorVersion = semver(reactNativeVersionString).minor
 
+if (reactNativeMinorVersion >= 59) {
+  upstreamTransformer = require('metro-react-native-babel-transformer/src/index')
+} else if (reactNativeMinorVersion >= 56) {
 if (reactNativeMinorVersion >= 56) {
   upstreamTransformer = require('metro/src/reactNativeTransformer')
 } else if (reactNativeMinorVersion >= 52) {

--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ const reactNativeMinorVersion = semver(reactNativeVersionString).minor
 if (reactNativeMinorVersion >= 59) {
   upstreamTransformer = require('metro-react-native-babel-transformer/src/index')
 } else if (reactNativeMinorVersion >= 56) {
-if (reactNativeMinorVersion >= 56) {
   upstreamTransformer = require('metro/src/reactNativeTransformer')
 } else if (reactNativeMinorVersion >= 52) {
   upstreamTransformer = require('metro/src/transformer')


### PR DESCRIPTION
Looks like the `reactNativeTransformer` has been moved out of `metro` and into its own package called `metro-react-native-babel-transformer` in RN versions >= 0.59.

This small patch updates the `require()` to the correct path.