### PR TITLE
feature: Support loading tsconfig JSON - fixes #74

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Jest All",
+            "program": "${workspaceFolder}/node_modules/.bin/jest",
+            "args": [
+                "--runInBand"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "windows": {
+                "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+            }
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Jest Current File",
+            "program": "${workspaceFolder}/node_modules/.bin/jest",
+            "args": [
+                "${fileBasenameNoExtension}"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "windows": {
+                "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+            }
+        }
+    ]
+}

--- a/__specs__/__fixtures__/tsconfigExtendsFile.json
+++ b/__specs__/__fixtures__/tsconfigExtendsFile.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfigNoExtends.json",
+    "compilerOptions": {
+        "tsconfigExtendsFile": true,
+        "overrideMe": "tsconfigExtendsFile"
+    }
+}

--- a/__specs__/__fixtures__/tsconfigExtendsFileRecursive.json
+++ b/__specs__/__fixtures__/tsconfigExtendsFileRecursive.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfigExtendsFile.json",
+    "compilerOptions": {
+        "tsconfigExtendsFileRecursive": true,
+        "overrideMe": "tsconfigExtendsFileRecursive"
+    }
+}

--- a/__specs__/__fixtures__/tsconfigExtendsModule.json
+++ b/__specs__/__fixtures__/tsconfigExtendsModule.json
@@ -1,0 +1,7 @@
+{
+    "extends": "@instacart/tsconfig",
+    "compilerOptions": {
+        "tsconfigExtendsModule": true,
+        "moduleResolution": "ES6"
+    }
+}

--- a/__specs__/__fixtures__/tsconfigExtendsModuleRecursive.json
+++ b/__specs__/__fixtures__/tsconfigExtendsModuleRecursive.json
@@ -1,0 +1,7 @@
+{
+    "extends": "@instacart/tsconfig/babel",
+    "compilerOptions": {
+        "tsconfigExtendsModuleRecursive": true,
+        "moduleResolution": "ES6"
+    }
+}

--- a/__specs__/__fixtures__/tsconfigNoExtends.json
+++ b/__specs__/__fixtures__/tsconfigNoExtends.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "tsconfigNoExtends": true,
+        "overrideMe": "tsconfigNoExtends"
+    }
+}

--- a/__specs__/extends.test.js
+++ b/__specs__/extends.test.js
@@ -1,0 +1,160 @@
+const transformer = require('../')
+const path = require('path')
+
+describe('Config extension', () => {
+  describe('Given a tsconfig that extends a relative config file', () => {
+    describe('When tsconfig is loaded', () => {
+      let config
+
+      beforeAll(() => {
+        process.env.TSCONFIG_PATH = path.resolve(
+          __dirname,
+          './__fixtures__/tsconfigExtendsFile.json'
+        )
+        config = transformer.loadTSConfig()
+      })
+
+      it('Should contain compiler options that are only defined in top level config', () => {
+        expect(config.compilerOptions.tsconfigExtendsFile).toBe(true)
+      })
+
+      it('Should retain compiler options defined in base config that are not overriden', () => {
+        expect(config.compilerOptions.tsconfigNoExtends).toBe(true)
+      })
+
+      it('Should override duplicate compiler options with values from highest level config', () => {
+        expect(config.compilerOptions.overrideMe).toBe('tsconfigExtendsFile')
+      })
+
+      afterAll(() => {
+        delete process.env.TSCONFIG_PATH
+      })
+    })
+  })
+
+  describe('Given a tsconfig that extends a multiple config files', () => {
+    describe('When tsconfig is loaded', () => {
+      let config
+
+      beforeAll(() => {
+        process.env.TSCONFIG_PATH = path.resolve(
+          __dirname,
+          './__fixtures__/tsconfigExtendsFileRecursive.json'
+        )
+        config = transformer.loadTSConfig()
+      })
+
+      it('Should contain compiler options that are only defined in top level config', () => {
+        expect(config.compilerOptions.tsconfigExtendsFileRecursive).toBe(true)
+      })
+
+      it('Should retain compiler options in middle config that are not overriden', () => {
+        expect(config.compilerOptions.tsconfigExtendsFile).toBe(true)
+      })
+
+      it('Should retain compiler options defined in base config that are not overriden', () => {
+        expect(config.compilerOptions.tsconfigNoExtends).toBe(true)
+      })
+
+      it('Should override duplicate compiler options with values from highest level config', () => {
+        expect(config.compilerOptions.overrideMe).toBe(
+          'tsconfigExtendsFileRecursive'
+        )
+      })
+
+      afterAll(() => {
+        delete process.env.TSCONFIG_PATH
+      })
+    })
+  })
+
+  describe('Given a tsconfig that extends a module config', () => {
+    describe('When tsconfig is loaded', () => {
+      let config
+
+      beforeAll(() => {
+        process.env.TSCONFIG_PATH = path.resolve(
+          __dirname,
+          './__fixtures__/tsconfigExtendsModule.json'
+        )
+        config = transformer.loadTSConfig()
+      })
+
+      afterAll(() => {
+        delete process.env.TSCONFIG_PATH
+      })
+
+      it('Should contain compiler options that are only defined in top level config', () => {
+        expect(config.compilerOptions.tsconfigExtendsModule).toBe(true)
+      })
+
+      it('Should retain compiler options defined in base config that are not overriden', () => {
+        expect(config.compilerOptions.strict).toBe(true)
+      })
+
+      it('Should override duplicate compiler options with values from highest level config', () => {
+        expect(config.compilerOptions.moduleResolution).toBe('ES6')
+      })
+    })
+  })
+
+  describe('Given a tsconfig that extends multiple module configs', () => {
+    describe('When tsconfig is loaded', () => {
+      let config
+
+      beforeAll(() => {
+        process.env.TSCONFIG_PATH = path.resolve(
+          __dirname,
+          './__fixtures__/tsconfigExtendsModuleRecursive.json'
+        )
+        config = transformer.loadTSConfig()
+      })
+
+      afterAll(() => {
+        delete process.env.TSCONFIG_PATH
+      })
+
+      it('Should contain compiler options that are only defined in top level config', () => {
+        expect(config.compilerOptions.tsconfigExtendsModuleRecursive).toBe(true)
+      })
+
+      it('Should retain compiler options in middle config that are not overriden', () => {
+        expect(config.compilerOptions.strict).toBe(true)
+      })
+
+      it('Should retain compiler options defined in base config that are not overriden', () => {
+        expect(config.compilerOptions.jsx).toBe('preserve')
+      })
+
+      it('Should override duplicate compiler options with values from highest level config', () => {
+        expect(config.compilerOptions.moduleResolution).toBe('ES6')
+      })
+    })
+  })
+
+  describe('Given a tsconfig that does not extend', () => {
+    describe('When tsconfig is loaded', () => {
+      let config
+
+      beforeAll(() => {
+        process.env.TSCONFIG_PATH = path.resolve(
+          __dirname,
+          './__fixtures__/tsconfigNoExtends.json'
+        )
+        config = transformer.loadTSConfig()
+      })
+
+      afterAll(() => {
+        delete process.env.TSCONFIG_PATH
+      })
+
+      it('Should contain compiler options that are only defined in top level config', () => {
+        expect(config.compilerOptions.tsconfigNoExtends).toBe(true)
+      })
+
+      it('Should override duplicate compiler options with values from highest level config', () => {
+        expect(config.compilerOptions.overrideMe).toBe('tsconfigNoExtends')
+      })
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "babel-traverse": "^6.26.0",
     "chalk": "^2.4.0",
+    "deepmerge": "^4.0.0",
     "find-root": "^1.1.0",
     "jju": "^1.3.0",
     "semver": "^5.4.1",
@@ -30,6 +31,7 @@
     ]
   },
   "devDependencies": {
+    "@instacart/tsconfig": "0.1.1",
     "babel-jest": "^20.0.0",
     "babel-preset-react-native": "^1.9.1",
     "eslint": "^3.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@instacart/tsconfig@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@instacart/tsconfig/-/tsconfig-0.1.1.tgz#66be16e77c5fa276b53b7417bde4013519b124a2"
+  integrity sha512-FKW7qt+asnUDlbKuuvXlx4bDOzrnaazeozcDW2p/vpN9K1a/nMvLNZIrQWlstA/VONHkE7Wx4o07mnCfScxwjw==
+
 abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
@@ -1481,6 +1486,11 @@ deep-extend@~0.4.0:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
+deepmerge@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.0.0.tgz#3e3110ca29205f120d7cb064960a39c3d2087c09"
+  integrity sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww==
 
 default-require-extensions@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### The problem:
Within a monorepo, we use extension of TS config via local files and a sharable node module. This allows the editor and `tsc` to type-check using project references etc, and for config to be kept consistent. The same mechanism for config extension is not supported by Metro (via babel), nor by react-native-typescript-transformer, so React Native sub projects cannot be compiled in the same manner at the moment.

Appreciate that this project is being superseded by the babel TS support, but as Metro only just introduced that, we and many others are still compiling via react-native-typescript-transformer. Therefore decided to fix it here first, to buy more time (as a fix will be needed for config extension in babel too)

### Solution supports:
- Can extend via absolute path, relative path, node module reference, and sub node module reference
- Recursive extension of configs for flexibility

### Examples
```
// absolute file
{
    "extends": "/usr/local/my-config.json",
    "compilerOptions": {
    }
}
```
```
// relative file
{
    "extends": "../my-config.json",
    "compilerOptions": {
    }
}
```
```
// node module path (resolves to the file referenced as "main" in the package)
{
    "extends": "ts-config",
    "compilerOptions": {
    }
}
```
```
// scoped node module path (resolves to the file referenced as "main" in the package)
{
    "extends": "@scope/ts-config",
    "compilerOptions": {
    }
}
```
```
// node module sub path (resolves to base.json in the package) 
{
    "extends": "@scope/ts-config/base",
    "compilerOptions": {
    }
}
```
 